### PR TITLE
[without-webhooks] server

### DIFF
--- a/without-webhooks/server/java/README.md
+++ b/without-webhooks/server/java/README.md
@@ -1,4 +1,4 @@
-# Taking a card payment on the web
+# Placing a hold
 
 ## Requirements
 * Maven

--- a/without-webhooks/server/java/README.md
+++ b/without-webhooks/server/java/README.md
@@ -1,4 +1,4 @@
-# Placing a hold
+# Taking a card payment on mobile
 
 ## Requirements
 * Maven

--- a/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
@@ -140,7 +140,7 @@ public class Server {
             try {
                 if (postBody.getPaymentIntentId() == null) {
                     int orderAmount = calculateOrderAmount(postBody.getItems());
-                    // Create new PaymentIntent with a payment method ID from the client.
+                    // Create new PaymentIntent with a PaymentMethod ID from the client.
                     PaymentIntentCreateParams createParams = new PaymentIntentCreateParams.Builder()
                             .setCurrency(postBody.getCurrency()).setAmount(new Long(orderAmount))
                             .setPaymentMethod(postBody.getPaymentMethodId())

--- a/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
@@ -144,9 +144,8 @@ public class Server {
                     PaymentIntentCreateParams createParams = new PaymentIntentCreateParams.Builder()
                             .setCurrency(postBody.getCurrency()).setAmount(new Long(orderAmount))
                             .setPaymentMethod(postBody.getPaymentMethodId())
-                            .setConfirmationMethod(PaymentIntentCreateParams.ConfirmationMethod.MANUAL)
-                            .setConfirm(true).
-                            .setUseStripeSdk(true).build();
+                            .setConfirmationMethod(PaymentIntentCreateParams.ConfirmationMethod.MANUAL).setConfirm(true)
+                            .build();
                     // Create a PaymentIntent with the order amount and currency
                     intent = PaymentIntent.create(createParams);
                 } else {

--- a/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
@@ -145,7 +145,8 @@ public class Server {
                             .setCurrency(postBody.getCurrency()).setAmount(new Long(orderAmount))
                             .setPaymentMethod(postBody.getPaymentMethodId())
                             .setConfirmationMethod(PaymentIntentCreateParams.ConfirmationMethod.MANUAL)
-                            .setConfirm(true).build();
+                            .setConfirm(true).
+                            .setUseStripeSdk(true).build();
                     // Create a PaymentIntent with the order amount and currency
                     intent = PaymentIntent.create(createParams);
                 } else {

--- a/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/without-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
@@ -140,18 +140,20 @@ public class Server {
             try {
                 if (postBody.getPaymentIntentId() == null) {
                     int orderAmount = calculateOrderAmount(postBody.getItems());
-                    // Create new PaymentIntent for the order
+                    // Create new PaymentIntent with a payment method ID from the client.
                     PaymentIntentCreateParams createParams = new PaymentIntentCreateParams.Builder()
                             .setCurrency(postBody.getCurrency()).setAmount(new Long(orderAmount))
                             .setPaymentMethod(postBody.getPaymentMethodId())
                             .setConfirmationMethod(PaymentIntentCreateParams.ConfirmationMethod.MANUAL).setConfirm(true)
                             .build();
-                    // Create a PaymentIntent with the order amount and currency
                     intent = PaymentIntent.create(createParams);
+                    // After create, if the PaymentIntent's status is succeeded, fulfill the order.
                 } else {
-                    // Confirm the PaymentIntent to collect the money
+                    // Confirm the PaymentIntent to finalize payment after handling a required
+                    // action on the client.
                     intent = PaymentIntent.retrieve(postBody.getPaymentIntentId());
                     intent = intent.confirm();
+                    // After confirm, if the PaymentIntent's status is succeeded, fulfill the order.
                 }
 
                 responseBody = generateResponse(intent, responseBody);

--- a/without-webhooks/server/node/README.md
+++ b/without-webhooks/server/node/README.md
@@ -1,4 +1,4 @@
-# Placing a hold
+# Taking a card payment on mobile
 An [Express server](http://expressjs.com) implementation
 
 ## Requirements

--- a/without-webhooks/server/node/README.md
+++ b/without-webhooks/server/node/README.md
@@ -1,4 +1,4 @@
-# Taking a card payment on the web
+# Placing a hold
 An [Express server](http://expressjs.com) implementation
 
 ## Requirements

--- a/without-webhooks/server/node/package.json
+++ b/without-webhooks/server/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stripe-placing-a-hold-manual-confirmation",
+  "name": "stripe-sample-mobile-elements-card-payment",
   "version": "1.0.0",
   "description": "How to take a card payment on mobile",
   "main": "index.js",

--- a/without-webhooks/server/node/package.json
+++ b/without-webhooks/server/node/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "@adreyfus-stripe",
+  "author": "stripe-samples",
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",

--- a/without-webhooks/server/node/package.json
+++ b/without-webhooks/server/node/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "stripe-sample-web-elements-card-payment",
+  "name": "stripe-placing-a-hold-manual-confirmation",
   "version": "1.0.0",
-  "description": "How to take a card payment on the web",
+  "description": "How to place a hold on a card",
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "stripe-samples",
+  "author": "@adreyfus-stripe",
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",

--- a/without-webhooks/server/node/package.json
+++ b/without-webhooks/server/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stripe-placing-a-hold-manual-confirmation",
   "version": "1.0.0",
-  "description": "How to place a hold on a card",
+  "description": "How to take a card payment on mobile",
   "main": "index.js",
   "scripts": {
     "start": "node server.js",

--- a/without-webhooks/server/node/server.js
+++ b/without-webhooks/server/node/server.js
@@ -38,21 +38,29 @@ const calculateOrderAmount = items => {
 };
 
 app.post("/pay", async (req, res) => {
-  const { paymentMethodId, paymentIntentId, items, currency } = req.body;
+  const {
+    paymentMethodId,
+    paymentIntentId,
+    items,
+    currency,
+    useStripeSdk
+  } = req.body;
 
   const orderAmount = calculateOrderAmount(items);
 
   try {
     let intent;
     if (!paymentIntentId) {
-      // Create new PaymentIntent
+      // Create new PaymentIntent.
+      // If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
+      // to take advantage of new authentication features in mobile SDKs.
       intent = await stripe.paymentIntents.create({
         amount: orderAmount,
         currency: currency,
         payment_method: paymentMethodId,
         confirmation_method: "manual",
         confirm: true,
-        use_stripe_sdk: true
+        use_stripe_sdk: useStripeSdk
       });
     } else {
       // Confirm the PaymentIntent to place a hold on the card

--- a/without-webhooks/server/node/server.js
+++ b/without-webhooks/server/node/server.js
@@ -51,7 +51,8 @@ app.post("/pay", async (req, res) => {
         currency: currency,
         payment_method: paymentMethodId,
         confirmation_method: "manual",
-        confirm: true
+        confirm: true,
+        use_stripe_sdk: true
       });
     } else {
       // Confirm the PaymentIntent to place a hold on the card

--- a/without-webhooks/server/node/server.js
+++ b/without-webhooks/server/node/server.js
@@ -51,7 +51,7 @@ app.post("/pay", async (req, res) => {
   try {
     let intent;
     if (!paymentIntentId) {
-      // Create new PaymentIntent with a payment method ID from the client.
+      // Create new PaymentIntent with a PaymentMethod ID from the client.
       // If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
       // to take advantage of new authentication features in mobile SDKs.
       intent = await stripe.paymentIntents.create({

--- a/without-webhooks/server/node/server.js
+++ b/without-webhooks/server/node/server.js
@@ -51,7 +51,7 @@ app.post("/pay", async (req, res) => {
   try {
     let intent;
     if (!paymentIntentId) {
-      // Create new PaymentIntent.
+      // Create new PaymentIntent with a payment method ID from the client.
       // If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
       // to take advantage of new authentication features in mobile SDKs.
       intent = await stripe.paymentIntents.create({
@@ -62,9 +62,12 @@ app.post("/pay", async (req, res) => {
         confirm: true,
         use_stripe_sdk: useStripeSdk
       });
+      // After create, if the PaymentIntent's status is succeeded, fulfill the order.
     } else {
-      // Confirm the PaymentIntent to place a hold on the card
+      // Confirm the PaymentIntent to finalize payment after handling a required action
+      // on the client.
       intent = await stripe.paymentIntents.confirm(paymentIntentId);
+      // After confirm, if the PaymentIntent's status is succeeded, fulfill the order.
     }
 
     const response = generateResponse(intent);

--- a/without-webhooks/server/php/README.md
+++ b/without-webhooks/server/php/README.md
@@ -1,4 +1,4 @@
-# Taking a card payment on the web
+# Placing a hold
 
 ## Requirements
 * PHP >= 7.1.3

--- a/without-webhooks/server/php/README.md
+++ b/without-webhooks/server/php/README.md
@@ -1,4 +1,4 @@
-# Placing a hold
+# Taking a card payment on mobile
 
 ## Requirements
 * PHP >= 7.1.3

--- a/without-webhooks/server/php/index.php
+++ b/without-webhooks/server/php/index.php
@@ -83,7 +83,7 @@ $app->post('/pay', function(Request $request, Response $response) use ($app)  {
   $body = json_decode($request->getBody());
 
   if($body->paymentIntentId == null) {
-    // Create new PaymentIntent
+    // Create new PaymentIntent with a payment method ID from the client.
     // If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
     // to take advantage of new authentication features in mobile SDKs
     $intent = \Stripe\PaymentIntent::create([
@@ -94,10 +94,13 @@ $app->post('/pay', function(Request $request, Response $response) use ($app)  {
       "confirm" => true,
       "use_stripe_sdk" => $body->useStripeSdk
     ]);
+    // After create, if the PaymentIntent's status is succeeded, fulfill the order.
   } else {
-    // Confirm the PaymentIntent to collect the money
+    // Confirm the PaymentIntent to finalize payment after handling a required action
+    // on the client.
     $intent = \Stripe\PaymentIntent::retrieve($body->paymentIntentId);
     $intent->confirm();
+    // After confirm, if the PaymentIntent's status is succeeded, fulfill the order.
   }
 
   $responseBody = generateResponse($intent, $logger);

--- a/without-webhooks/server/php/index.php
+++ b/without-webhooks/server/php/index.php
@@ -89,7 +89,8 @@ $app->post('/pay', function(Request $request, Response $response) use ($app)  {
       "currency" => $body->currency,
       "payment_method" => $body->paymentMethodId,
       "confirmation_method" => "manual",
-      "confirm" => true
+      "confirm" => true,
+      "use_stripe_sdk" => true
     ]);
   } else {
     // Confirm the PaymentIntent to collect the money

--- a/without-webhooks/server/php/index.php
+++ b/without-webhooks/server/php/index.php
@@ -84,13 +84,15 @@ $app->post('/pay', function(Request $request, Response $response) use ($app)  {
 
   if($body->paymentIntentId == null) {
     // Create new PaymentIntent
+    // If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
+    // to take advantage of new authentication features in mobile SDKs
     $intent = \Stripe\PaymentIntent::create([
       "amount" => calculateOrderAmount($body->items),
       "currency" => $body->currency,
       "payment_method" => $body->paymentMethodId,
       "confirmation_method" => "manual",
       "confirm" => true,
-      "use_stripe_sdk" => true
+      "use_stripe_sdk" => $body->useStripeSdk
     ]);
   } else {
     // Confirm the PaymentIntent to collect the money

--- a/without-webhooks/server/php/index.php
+++ b/without-webhooks/server/php/index.php
@@ -83,7 +83,7 @@ $app->post('/pay', function(Request $request, Response $response) use ($app)  {
   $body = json_decode($request->getBody());
 
   if($body->paymentIntentId == null) {
-    // Create new PaymentIntent with a payment method ID from the client.
+    // Create new PaymentIntent with a PaymentMethod ID from the client.
     // If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
     // to take advantage of new authentication features in mobile SDKs
     $intent = \Stripe\PaymentIntent::create([

--- a/without-webhooks/server/python/README.md
+++ b/without-webhooks/server/python/README.md
@@ -1,4 +1,4 @@
-# Taking a card payment on the web
+# Placing a hold
 
 ## Requirements
 

--- a/without-webhooks/server/python/README.md
+++ b/without-webhooks/server/python/README.md
@@ -1,4 +1,4 @@
-# Placing a hold
+# Taking a card payment on mobile
 
 ## Requirements
 

--- a/without-webhooks/server/python/server.py
+++ b/without-webhooks/server/python/server.py
@@ -49,13 +49,15 @@ def pay():
             order_amount = calculate_order_amount(data['items'])
 
             # Create a new PaymentIntent for the order
+            # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
+            # to take advantage of new authentication features in mobile SDKs.
             intent = stripe.PaymentIntent.create(
                 amount=order_amount,
                 currency=data['currency'],
                 payment_method=data['paymentMethodId'],
                 confirmation_method='manual',
                 confirm=True,
-                use_stripe_sdk=True
+                use_stripe_sdk=data['useStripeSdk']
             )
         else:
             # Confirm the PaymentIntent to collect the money

--- a/without-webhooks/server/python/server.py
+++ b/without-webhooks/server/python/server.py
@@ -18,9 +18,11 @@ load_dotenv(find_dotenv())
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 stripe.api_version = os.getenv('STRIPE_API_VERSION')
 
-static_dir = str(os.path.abspath(os.path.join(__file__ , "..", os.getenv("STATIC_DIR"))))
+static_dir = str(os.path.abspath(os.path.join(
+    __file__, "..", os.getenv("STATIC_DIR"))))
 app = Flask(__name__, static_folder=static_dir,
             static_url_path="", template_folder=static_dir)
+
 
 @app.route('/', methods=['GET'])
 def get_example():
@@ -48,7 +50,7 @@ def pay():
         if "paymentIntentId" not in data:
             order_amount = calculate_order_amount(data['items'])
 
-            # Create a new PaymentIntent for the order
+            # Create new PaymentIntent with a payment method ID from the client.
             # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
             # to take advantage of new authentication features in mobile SDKs.
             intent = stripe.PaymentIntent.create(
@@ -59,9 +61,12 @@ def pay():
                 confirm=True,
                 use_stripe_sdk=data['useStripeSdk']
             )
+            # After create, if the PaymentIntent's status is succeeded, fulfill the order.
         else:
-            # Confirm the PaymentIntent to collect the money
+            # Confirm the PaymentIntent to finalize payment after handling a required action
+            # on the client.
             intent = stripe.PaymentIntent.confirm(data['paymentIntentId'])
+            # After confirm, if the PaymentIntent's status is succeeded, fulfill the order.
 
         return generate_response(intent)
     except Exception as e:

--- a/without-webhooks/server/python/server.py
+++ b/without-webhooks/server/python/server.py
@@ -50,7 +50,7 @@ def pay():
         if "paymentIntentId" not in data:
             order_amount = calculate_order_amount(data['items'])
 
-            # Create new PaymentIntent with a payment method ID from the client.
+            # Create new PaymentIntent with a PaymentMethod ID from the client.
             # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
             # to take advantage of new authentication features in mobile SDKs.
             intent = stripe.PaymentIntent.create(

--- a/without-webhooks/server/python/server.py
+++ b/without-webhooks/server/python/server.py
@@ -54,7 +54,8 @@ def pay():
                 currency=data['currency'],
                 payment_method=data['paymentMethodId'],
                 confirmation_method='manual',
-                confirm=True
+                confirm=True,
+                use_stripe_sdk=True
             )
         else:
             # Confirm the PaymentIntent to collect the money

--- a/without-webhooks/server/ruby/README.md
+++ b/without-webhooks/server/ruby/README.md
@@ -1,4 +1,4 @@
-# Placing a hold
+# Taking a card payment on mobile
 
 A [Sinatra](http://sinatrarb.com/) implementation.
 

--- a/without-webhooks/server/ruby/README.md
+++ b/without-webhooks/server/ruby/README.md
@@ -1,4 +1,4 @@
-# Taking a card payment on the web
+# Placing a hold
 
 A [Sinatra](http://sinatrarb.com/) implementation.
 

--- a/without-webhooks/server/ruby/server.rb
+++ b/without-webhooks/server/ruby/server.rb
@@ -38,7 +38,7 @@ post '/pay' do
 
   begin
     if !data['paymentIntentId']
-      # Create a new PaymentIntent with a payment method ID from the client.
+      # Create a new PaymentIntent with a PaymentMethod ID from the client.
       # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
       # to take advantage of new authentication features in mobile SDKs.
       intent = Stripe::PaymentIntent.create(

--- a/without-webhooks/server/ruby/server.rb
+++ b/without-webhooks/server/ruby/server.rb
@@ -44,7 +44,8 @@ post '/pay' do
         currency: data['currency'],
         payment_method: data['paymentMethodId'],
         confirmation_method: 'manual',
-        confirm: true
+        confirm: true,
+        use_stripe_sdk: true
       )
     else
       # Confirm the PaymentIntent to collect the money

--- a/without-webhooks/server/ruby/server.rb
+++ b/without-webhooks/server/ruby/server.rb
@@ -38,14 +38,16 @@ post '/pay' do
 
   begin
     if !data['paymentIntentId']
-      # Create a new PaymentIntent for the order
+      # Create a new PaymentIntent for the order.
+      # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
+      # to take advantage of new authentication features in mobile SDKs.
       intent = Stripe::PaymentIntent.create(
         amount: order_amount,
         currency: data['currency'],
         payment_method: data['paymentMethodId'],
         confirmation_method: 'manual',
         confirm: true,
-        use_stripe_sdk: true
+        use_stripe_sdk: data['useStripeSdk']
       )
     else
       # Confirm the PaymentIntent to collect the money

--- a/without-webhooks/server/ruby/server.rb
+++ b/without-webhooks/server/ruby/server.rb
@@ -38,7 +38,7 @@ post '/pay' do
 
   begin
     if !data['paymentIntentId']
-      # Create new PaymentIntent with a payment method ID from the client.
+      # Create a new PaymentIntent with a payment method ID from the client.
       # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
       # to take advantage of new authentication features in mobile SDKs.
       intent = Stripe::PaymentIntent.create(

--- a/without-webhooks/server/ruby/server.rb
+++ b/without-webhooks/server/ruby/server.rb
@@ -38,7 +38,7 @@ post '/pay' do
 
   begin
     if !data['paymentIntentId']
-      # Create a new PaymentIntent for the order.
+      # Create new PaymentIntent with a payment method ID from the client.
       # If the client passes `useStripeSdk`, set `use_stripe_sdk=true`
       # to take advantage of new authentication features in mobile SDKs.
       intent = Stripe::PaymentIntent.create(
@@ -49,9 +49,12 @@ post '/pay' do
         confirm: true,
         use_stripe_sdk: data['useStripeSdk']
       )
+      # After create, if the PaymentIntent's status is succeeded, fulfill the order.
     else
-      # Confirm the PaymentIntent to collect the money
+      # Confirm the PaymentIntent to finalize payment after handling a required action
+      # on the client.
       intent = Stripe::PaymentIntent.confirm(data['paymentIntentId'])
+      # After confirm, if the PaymentIntent's status is succeeded, fulfill the order.
     end
 
     generate_response(intent)


### PR DESCRIPTION
- [x] reframe second confirmation step in server endpoint, adding comment for clarity
Related: https://github.com/stripe-samples/web-elements-card-payment/pull/2

- [x] add `use_stripe_sdk` and comments on why this is important: "pass this and Stripe will configure the response to take advantage of features in the iOS/Android SDK"

Note: I'm leaving use_stripe_sdk out of the java sample for now, since it isn't supported in bindings 😞 

- [ ] file a task: use_stripe_sdk isn't supported in stripe-java https://github.com/stripe/stripe-java/blob/master/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
- Might be codegen/open-api related?

- [ ] confirm that we don't need to pass a `return_url` anymore. When is it necessary to specify a return_url? Should we remove this from docs?

https://stripe.com/docs/payments/payment-intents/ios-manual#create-and-confirm-payment-intent-manual
![image](https://user-images.githubusercontent.com/23086960/65932226-9c2e8b00-e3c1-11e9-84a5-8225b4efd486.png)

## Testing

curl -d '{"currency":"usd","items":["foo"],"paymentMethodId":"pi_123"}' http://localhost:4242/pay -H "Content-Type: application/json" -X POST

curl -d '{"currency":"usd","items":["foo"],"paymentMethodId":"pi_123","use_stripe_sdk": true}' http://localhost:4242/pay -H "Content-Type: application/json" -X POST


- [ ] java
- [ ] node 
- [ ] php 
- [ ] python 
- [ ] ruby