### PR TITLE
[using-webhooks] server

### DIFF
--- a/using-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/using-webhooks/server/java/src/main/java/com/stripe/sample/Server.java
@@ -72,7 +72,9 @@ public class Server {
 
             CreatePaymentBody postBody = gson.fromJson(request.body(), CreatePaymentBody.class);
             PaymentIntentCreateParams createParams = new PaymentIntentCreateParams.Builder()
-                    .setCurrency(postBody.getCurrency()).setAmount(new Long(calculateOrderAmount(postBody.getItems())))
+                    .setCurrency(postBody.getCurrency())
+                    .setAmount(new Long(calculateOrderAmount(postBody.getItems())))
+                    .setUseStripeSdk(true)
                     .build();
             // Create a PaymentIntent with the order amount and currency
             PaymentIntent intent = PaymentIntent.create(createParams);

--- a/using-webhooks/server/node/server.js
+++ b/using-webhooks/server/node/server.js
@@ -38,7 +38,8 @@ app.post("/create-payment-intent", async (req, res) => {
   // Create a PaymentIntent with the order amount and currency
   const paymentIntent = await stripe.paymentIntents.create({
     amount: calculateOrderAmount(items),
-    currency: currency
+    currency: currency,
+    use_stripe_sdk: true
   });
 
   // Send public key and PaymentIntent details to client

--- a/using-webhooks/server/php/index.php
+++ b/using-webhooks/server/php/index.php
@@ -53,7 +53,8 @@ $app->post('/create-payment-intent', function (Request $request, Response $respo
     // Create a PaymentIntent with the order amount and currency
     $payment_intent = \Stripe\PaymentIntent::create([
       "amount" => calculateOrderAmount($body->items),
-      "currency" => $body->currency
+      "currency" => $body->currency,
+      "use_stripe_sdk" => true
     ]);
     
     // Send public key and PaymentIntent details to client

--- a/using-webhooks/server/python/server.py
+++ b/using-webhooks/server/python/server.py
@@ -42,7 +42,8 @@ def create_payment():
     # Create a PaymentIntent with the order amount and currency
     intent = stripe.PaymentIntent.create(
         amount=calculate_order_amount(data['items']),
-        currency=data['currency']
+        currency=data['currency'],
+        use_stripe_sdk=True
     )
 
     try:

--- a/using-webhooks/server/ruby/server.rb
+++ b/using-webhooks/server/ruby/server.rb
@@ -31,7 +31,8 @@ post '/create-payment-intent' do
   # Create a PaymentIntent with the order amount and currency
   payment_intent = Stripe::PaymentIntent.create(
     amount: calculate_order_amount(data['items']),
-    currency: data['currency']
+    currency: data['currency'],
+    use_stripe_sdk: true
   )
 
   # Send public key and PaymentIntent details to client


### PR DESCRIPTION
Based on docs, I don't think you need to set `use_stripe_sdk` for automatic confirmation / this using-webhooks sample...

For more background, see https://paper.dropbox.com/doc/feedback-use_stripe_sdk-in-mobile-SDK-docs--Als386HAq~HALc8OQtf6kLCtAg-LMsvY8ZMUpwvAV5ZTSZQs

- [x] confirm whether `use_stripe_sdk` is necessary for this sample

## Testing
curl -d '{"currency":"usd","items":["foo"]}' http://localhost:4242/create-payment-intent -H "Content-Type: application/json" -X POST

- [ ] java
- [x] node
- [ ] php
- [ ] python
- [ ] ruby