### PR TITLE
Various fixes

### DIFF
--- a/using-webhooks/client/android-java/app/src/main/java/com/example/app/CheckoutActivity.java
+++ b/using-webhooks/client/android-java/app/src/main/java/com/example/app/CheckoutActivity.java
@@ -58,10 +58,10 @@ public class CheckoutActivity extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_checkout);
-        loadPage();
+        startCheckout();
     }
 
-    private void loadPage() {
+    private void startCheckout() {
         // Create a PaymentIntent by calling the sample server's /create-payment-intent endpoint.
         MediaType mediaType = MediaType.get("application/json; charset=utf-8");
         String json = "{"
@@ -130,7 +130,7 @@ public class CheckoutActivity extends AppCompatActivity {
             builder.setPositiveButton("Restart demo", (DialogInterface dialog, int index) -> {
                 CardInputWidget cardInputWidget = findViewById(R.id.cardInputWidget);
                 cardInputWidget.clear();
-                loadPage();
+                startCheckout();
             });
         } else {
             builder.setPositiveButton("Ok", null);

--- a/using-webhooks/client/ios-objc/app/CheckoutViewController.m
+++ b/using-webhooks/client/ios-objc/app/CheckoutViewController.m
@@ -92,7 +92,7 @@ NSString *const BackendUrl = @"http://127.0.0.1:4242/";
         NSError *error = requestError;
         NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-        if (error != nil || httpResponse.statusCode != 200 || json[@"publicKey"] == nil) {
+        if (error != nil || httpResponse.statusCode != 200 || json[@"publishableKey"] == nil) {
             [self displayAlertWithTitle:@"Error loading page" message:error.localizedDescription ?: @"" restartDemo:NO];
         }
         else {

--- a/using-webhooks/server/php/README.md
+++ b/using-webhooks/server/php/README.md
@@ -15,5 +15,5 @@ composer install
 2. Run the server locally
 
 ```
-php -S localhost:4242 index.php
+php -S 127.0.0.1:4242 index.php
 ```

--- a/using-webhooks/server/ruby/README.md
+++ b/using-webhooks/server/ruby/README.md
@@ -15,5 +15,5 @@ bundle install
 
 2. Run the server locally
 ```
-ruby server.rb
+ruby server.rb -o 127.0.0.1
 ```

--- a/without-webhooks/client/android-java/app/src/main/java/com/example/app/CheckoutActivity.java
+++ b/without-webhooks/client/android-java/app/src/main/java/com/example/app/CheckoutActivity.java
@@ -146,6 +146,7 @@ public class CheckoutActivity extends AppCompatActivity {
         String json;
         if (paymentMethod != null) {
             json = "{"
+                    + "\"useStripeSdk\":true,"
                     + "\"paymentMethodId\":" + "\"" + paymentMethod + "\","
                     + "\"currency\":\"usd\","
                     + "\"items\":["

--- a/without-webhooks/client/android-kotlin/app/src/main/java/com/example/app/CheckoutActivity.kt
+++ b/without-webhooks/client/android-kotlin/app/src/main/java/com/example/app/CheckoutActivity.kt
@@ -136,6 +136,7 @@ class CheckoutActivity : AppCompatActivity() {
         if (!paymentMethod.isNullOrEmpty()) {
             json = """
                 {
+                    "useStripeSdk":true,
                     "paymentMethodId":"$paymentMethod",
                     "currency":"usd",
                     "items": [

--- a/without-webhooks/client/ios-objc/Podfile.lock
+++ b/without-webhooks/client/ios-objc/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Stripe (17.0.2)
+  - Stripe (18.0.0)
 
 DEPENDENCIES:
   - Stripe
@@ -9,7 +9,7 @@ SPEC REPOS:
     - Stripe
 
 SPEC CHECKSUMS:
-  Stripe: 6c9ab10f087ca76c3cd7311462e383434921bdf8
+  Stripe: 8c9ac6b717a38ed4f373d4db9204cfe8c4120d65
 
 PODFILE CHECKSUM: 2c7bdf831495598c950f9cb33744e89508da0ea8
 

--- a/without-webhooks/client/ios-objc/app/CheckoutViewController.m
+++ b/without-webhooks/client/ios-objc/app/CheckoutViewController.m
@@ -117,6 +117,7 @@ NSString *const BackendUrl = @"http://127.0.0.1:4242/";
     NSDictionary *json = @{};
     if (paymentMethodId != nil) {
         json = @{
+            @"useStripeSdk": @YES,
             @"paymentMethodId": paymentMethodId,
             @"currency": @"usd",
             @"items": @[

--- a/without-webhooks/client/ios-swift/Podfile.lock
+++ b/without-webhooks/client/ios-swift/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Stripe (17.0.2)
+  - Stripe (18.0.0)
 
 DEPENDENCIES:
   - Stripe
@@ -9,7 +9,7 @@ SPEC REPOS:
     - Stripe
 
 SPEC CHECKSUMS:
-  Stripe: 6c9ab10f087ca76c3cd7311462e383434921bdf8
+  Stripe: 8c9ac6b717a38ed4f373d4db9204cfe8c4120d65
 
 PODFILE CHECKSUM: 2c7bdf831495598c950f9cb33744e89508da0ea8
 

--- a/without-webhooks/client/ios-swift/app/CheckoutViewController.swift
+++ b/without-webhooks/client/ios-swift/app/CheckoutViewController.swift
@@ -111,6 +111,7 @@ class CheckoutViewController: UIViewController {
         var json: [String: Any] = [:]
         if let paymentMethodId = paymentMethodId {
             json = [
+                "useStripeSdk": true,
                 "paymentMethodId": paymentMethodId,
                 "currency": "usd",
                 "items": [


### PR DESCRIPTION
See commits

## Testing
Tested 3220 for all `without-webhooks` clients with a modified server that also sends `return_url`.  `use_stripe_sdk` defaults to `true` if `return_url` is not passed.

